### PR TITLE
Fix backtrace with signal handlers interrupting

### DIFF
--- a/util/backtrace.c
+++ b/util/backtrace.c
@@ -6,6 +6,12 @@
 #define __LDINFO_PTRACE32__
 #endif
 
+#ifdef __powerpc64__
+#define TRAMPOLINE_OFFSET 0xA8
+#else
+#define TRAMPOLINE_OFFSET 0x11C
+#endif
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -15,6 +21,7 @@
 #include <execinfo.h>
 
 #include <sys/ldr.h>
+#include <sys/seg.h>
 #include <xcoff.h>
 
 #include <assert.h>
@@ -76,13 +83,8 @@ size_t backtrace(void** frames, size_t count)
         // the displacement is verified to be the proper offset by GDB, and we
         // employ a similar heuristic.
         // XXX: What about syscalls?
-        if (lr < (void*)0x10000000 /* TEXTORG */) {
-#ifdef __powerpc64__
-            sp = (void*)((uint64_t)sp + 0xA8);
-#else
-            // XXX: PPC32 displacement untested
-            sp = (void*)((uint32_t)sp + 0x11C);
-#endif
+        if (lr < (void*)TEXTORG) {
+            sp = (void*)((uint64_t)sp + TRAMPOLINE_OFFSET);
         }
     }
     

--- a/util/backtrace.c
+++ b/util/backtrace.c
@@ -64,7 +64,26 @@ size_t backtrace(void** frames, size_t count)
     // Walk the stack up to count times or we hit the bottom
     // of the stack (whichever is first)
     for(i = 0; i < count && sp; ++i, sp = (void**) sp[0]) {
-        frames[i] = sp[2];
+        void *lr = sp[2];
+        frames[i] = lr;
+        // This might be a signal handler frame, which means the back chain is
+        // useless (missing/in the weeds), so look at what's in the frame. In
+        // this case, what would be the back chain is in one of the fields of
+        // the frame. We need to guess if this is a signal handler frame
+        // though; our heuristic is the address being lower than the base of
+        // text; the signal trampoline is around ~0x3680 under PASE, but AIX
+        // has it at a different address around ~0x4800. The value we use for
+        // the displacement is verified to be the proper offset by GDB, and we
+        // employ a similar heuristic.
+        // XXX: What about syscalls?
+        if (lr < (void*)0x10000000 /* TEXTORG */) {
+#ifdef __powerpc64__
+            sp = (void*)((uint64_t)sp + 0xA8);
+#else
+            // XXX: PPC32 displacement untested
+            sp = (void*)((uint32_t)sp + 0x11C);
+#endif
+        }
     }
     
     return i;


### PR DESCRIPTION
When an application (in my case, Mono), tries to get a backtrace
from a signal handler, it'll either stop because the backchain is
NULL (PASE) or fault again in the handler because it's some other
nonsensical value (AIX). This applies a heuristic to determine if
the frame is a signal handler, and if so, resets the stack pointer
to a location where the true backchain in the handler frame is
stored. The displacements used and idea of looking below the .text
base are inspired by how GDB attempts to handle this situation.

This commit fixes the issue and allows application signal handlers
to see the full backtrace, from before the signal was caught.