### PR TITLE
Add flock implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: build-all
 
 install: install-all
 
-util/libutil.o: util/getopt_long.o util/pty.o util/mkdtemp.o util/backtrace.o
+util/libutil.o: util/getopt_long.o util/pty.o util/mkdtemp.o util/backtrace.o util/bsd-flock.o
 	$(CC) -shared $(CFLAGS) $(LDFLAGS) -Wl,-bE:util/libutil.exp -o $@ $^
 
 util/%.o: util/%.c
@@ -41,9 +41,11 @@ install-util-libutil: util/libutil.so util/libutil.so.2
 	/QOpenSys/usr/bin/cp -h util/libutil.so $(DESTDIR)$(PREFIX)/lib
 	/QOpenSys/usr/bin/cp -h util/libutil.so.2 $(DESTDIR)$(PREFIX)/lib
 	mkdir -p $(DESTDIR)$(PREFIX)/include
-	cp util/getopt.h $(DESTDIR)$(PREFIX)/include
-	cp util/pty.h $(DESTDIR)$(PREFIX)/include
-	cp util/execinfo.h $(DESTDIR)$(PREFIX)/include
+	mkdir -p $(DESTDIR)$(PREFIX)/include/sys
+	cp util/getopt.h $(DESTDIR)$(PREFIX)/include/getopt.h
+	cp util/pty.h $(DESTDIR)$(PREFIX)/include/pty.h
+	cp util/execinfo.h $(DESTDIR)$(PREFIX)/include/execinfo.h
+	cp util/file.h $(DESTDIR)$(PREFIX)/include/sys/file.h
 
 perfstat/libiperf.o: perfstat/iperfstat_cpu.o perfstat/iperfstat_memory.o
 	$(CC) -shared $(CFLAGS) $(LDFLAGS) -Wl,-bE:perfstat/libiperf.exp -o $@ $^
@@ -78,7 +80,7 @@ install-perfstat-libiperf: perfstat/libiperf.so perfstat/libiperf.so.1
 	/QOpenSys/usr/bin/cp -h perfstat/libiperf.so $(DESTDIR)$(PREFIX)/lib
 	/QOpenSys/usr/bin/cp -h perfstat/libiperf.so.1 $(DESTDIR)$(PREFIX)/lib
 	mkdir -p $(DESTDIR)$(PREFIX)/include
-	cp perfstat/libiperf.h $(DESTDIR)$(PREFIX)/include
+	cp perfstat/libiperf.h $(DESTDIR)$(PREFIX)/include/libiperf.h
 
 build-all: util/libutil.target perfstat/libiperf.target
 

--- a/generate.py
+++ b/generate.py
@@ -93,8 +93,24 @@ for cfg in glob('*/build.json'):
 
         if 'includes' in install:
             print(f"	mkdir -p $(DESTDIR)$(PREFIX)/include")
-            for include in install['includes']:
-                print(f"	cp {cfg_dir}/{include} $(DESTDIR)$(PREFIX)/include")
+
+            dirs = set()
+            for item in install['includes']:
+                dstfile = item if isinstance(item, str) else item[1]
+
+                directory = dirname(dstfile)
+                if not directory or directory in dirs:
+                    continue
+
+                dirs.add(directory)
+                print(f"	mkdir -p $(DESTDIR)$(PREFIX)/include/{directory}")
+
+            for item in install['includes']:
+                if isinstance(item, str):
+                    srcfile = dstfile = item
+                else:
+                    srcfile, dstfile = item
+                print(f"	cp {cfg_dir}/{srcfile} $(DESTDIR)$(PREFIX)/include/{dstfile}")
     print()
         
 print(f"""

--- a/util/bsd-flock.c
+++ b/util/bsd-flock.c
@@ -1,0 +1,73 @@
+/*	$NetBSD: flock.c,v 1.6 2008/04/28 20:24:12 martin Exp $	*/
+
+/*-
+ * Copyright (c) 2001 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Todd Vierling.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Emulate flock() with fcntl()
+ * Based on https://github.com/openssh/openssh-portable/blob/5aea4aa/openbsd-compat/bsd-flock.c
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/file.h>
+
+int
+libutil_flock(int fd, int op)
+{
+	int rc = 0;
+
+	struct flock fl = {0};
+
+	switch (op & (LOCK_EX|LOCK_SH|LOCK_UN)) {
+	case LOCK_EX:
+		fl.l_type = F_WRLCK;
+		break;
+
+	case LOCK_SH:
+		fl.l_type = F_RDLCK;
+		break;
+
+	case LOCK_UN:
+		fl.l_type = F_UNLCK;
+		break;
+
+	default:
+		errno = EINVAL;
+		return -1;
+	}
+
+	fl.l_whence = SEEK_SET;
+	rc = fcntl(fd, op & LOCK_NB ? F_SETLK : F_SETLKW, &fl);
+
+	if (rc && (errno == EAGAIN))
+		errno = EWOULDBLOCK;
+
+	return rc;
+}

--- a/util/build.json
+++ b/util/build.json
@@ -8,7 +8,8 @@
                 "getopt_long.o",
                 "pty.o",
                 "mkdtemp.o",
-                "backtrace.o"
+                "backtrace.o",
+                "bsd-flock.o"
             ]
         }
     ],
@@ -16,7 +17,8 @@
         "includes": [
             "getopt.h",
             "pty.h",
-            "execinfo.h"            
+            "execinfo.h",
+            ["file.h", "sys/file.h"]
         ]
     }
 }

--- a/util/file.h
+++ b/util/file.h
@@ -1,0 +1,19 @@
+#ifndef LIBUTIL_SYS_FILE_H
+#define LIBUTIL_SYS_FILE_H
+
+/* Include the real sys/file.h. We don't want to recreate all the stuff */
+/* it contains - just override flock */
+#include_next <sys/file.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Amazingly, this works on XLC 13.1.2 */
+extern int flock(int fd, int operation)  __asm__("libutil_flock");
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/util/libutil.exp
+++ b/util/libutil.exp
@@ -7,3 +7,4 @@ login_tty
 mkdtemp
 backtrace
 backtrace_symbols
+libutil_flock


### PR DESCRIPTION
This is an implementation of flock(), pulled from the OpenSSH sources.

While AIX ships an flock implementation, it's in libbsd, which is
troublesome for many portable applications to use since it has
conflicting definitions of timezone. This can cause libc functions
gmtime, localtime, etc to fail in interesting ways.

Instead, we provide a definition in libutil, which does not conflict
with the version in libbsd so applications can use flock() without these
problems.