### PR TITLE
feat: Add backtrace_symbols_fd

### DIFF
--- a/util/execinfo.h
+++ b/util/execinfo.h
@@ -10,6 +10,8 @@ size_t backtrace(void** buffer, size_t size);
 
 char** backtrace_symbols(void* const* frames, size_t size);
 
+void backtrace_symbols_fd(void *const *frames, size_t count, int fd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/util/libutil.exp
+++ b/util/libutil.exp
@@ -7,4 +7,5 @@ login_tty
 mkdtemp
 backtrace
 backtrace_symbols
+backtrace_symbols_fd
 libutil_flock


### PR DESCRIPTION
Move symbol generation in to its own function. This seems rather
superfluous right now, but will be more important once we start reading
debug info.

Fixes #3