### PR TITLE
fix: backtrace segmentation fault

### DIFF
--- a/util/backtrace.c
+++ b/util/backtrace.c
@@ -83,7 +83,7 @@ size_t backtrace(void** frames, size_t count)
         // the displacement is verified to be the proper offset by GDB, and we
         // employ a similar heuristic.
         // XXX: What about syscalls?
-        if (lr < (void*)TEXTORGi && lr != NULL) {
+        if (lr < (void*)TEXTORG && lr != NULL) {
             sp = (void*)((uint64_t)sp + TRAMPOLINE_OFFSET);
         }
     }

--- a/util/backtrace.c
+++ b/util/backtrace.c
@@ -83,7 +83,7 @@ size_t backtrace(void** frames, size_t count)
         // the displacement is verified to be the proper offset by GDB, and we
         // employ a similar heuristic.
         // XXX: What about syscalls?
-        if (lr < (void*)TEXTORG) {
+        if (lr < (void*)TEXTORGi && lr != 0) {
             sp = (void*)((uint64_t)sp + TRAMPOLINE_OFFSET);
         }
     }

--- a/util/backtrace.c
+++ b/util/backtrace.c
@@ -83,7 +83,7 @@ size_t backtrace(void** frames, size_t count)
         // the displacement is verified to be the proper offset by GDB, and we
         // employ a similar heuristic.
         // XXX: What about syscalls?
-        if (lr < (void*)TEXTORGi && lr != 0) {
+        if (lr < (void*)TEXTORGi && lr != NULL) {
             sp = (void*)((uint64_t)sp + TRAMPOLINE_OFFSET);
         }
     }


### PR DESCRIPTION
Fixes #12

This problem affects running backtrace from pthread as the bottom of the pthread stack will always have a NULL return address.