### PR TITLE
fix: asprint.c build error

### DIFF
--- a/util/asprintf.c
+++ b/util/asprintf.c
@@ -2,8 +2,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-extern int vasprintf(char **ret, const char *format, va_list args)  __asm__("libutil_vasprintf");
-
 int libutil_vasprintf(char **ret, const char *format, va_list args)
 {
     *ret = NULL;
@@ -37,7 +35,7 @@ int libutil_asprintf(char **ret, const char *format, ...)
   int r;
   va_list args;
   va_start(args, format);
-  r = vasprintf(ret, format, args);
+  r = libutil_vasprintf(ret, format, args);
   va_end(args);
   return r;
 }

--- a/util/asprintf.c
+++ b/util/asprintf.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+extern int vasprintf(char **ret, const char *format, va_list args)  __asm__("libutil_vasprintf");
+
 int libutil_vasprintf(char **ret, const char *format, va_list args)
 {
     *ret = NULL;


### PR DESCRIPTION
Currently the build fails with the following

```
util/asprintf.c: In function 'libutil_asprintf':
util/asprintf.c:38:7: warning: implicit declaration of function 'vasprintf' [-Wimplicit-function-declaration]
   r = vasprintf(ret, format, args);
       ^~~~~~~~~
```

Now we just make `libutil_asprintf` call `libutil_vasprintf`.