### PR TITLE
Implement FNM_CASEFOLD for the fnmatch function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install-perfstat-libiperf: perfstat/libiperf.so perfstat/libiperf.so.1
 	mkdir -p $(DESTDIR)$(PREFIX)/include
 	cp perfstat/libiperf.h $(DESTDIR)$(PREFIX)/include/libiperf.h
 
-util/libutil.o: util/getopt_long.o util/pty.o util/mkdtemp.o util/backtrace.o util/bsd-flock.o util/asprintf.o util/progname.o util/err.o util/isatty.o
+util/libutil.o: util/getopt_long.o util/pty.o util/mkdtemp.o util/backtrace.o util/bsd-flock.o util/asprintf.o util/progname.o util/err.o util/isatty.o util/fnmatch.o
 	$(CC) -shared $(CFLAGS) $(LDFLAGS) -Wl,-bE:util/libutil.exp -o $@ $^
 
 util/%.o: util/%.c
@@ -84,6 +84,7 @@ install-util-libutil: util/libutil.so util/libutil.so.2
 	cp util/wrapper/stdio.h $(DESTDIR)$(PREFIX)/include/stdio.h
 	cp util/wrapper/unistd.h $(DESTDIR)$(PREFIX)/include/unistd.h
 	cp util/wrapper/stdlib.h $(DESTDIR)$(PREFIX)/include/stdlib.h
+	cp util/wrapper/fnmatch.h $(DESTDIR)$(PREFIX)/include/fnmatch.h
 	cp util/err.h $(DESTDIR)$(PREFIX)/include/err.h
 
 build-all: perfstat/libiperf.target util/libutil.target

--- a/util/build.json
+++ b/util/build.json
@@ -13,7 +13,8 @@
                 "asprintf.o",
                 "progname.o",
                 "err.o",
-                "isatty.o"
+                "isatty.o",
+                "fnmatch.o"
             ]
         }
     ],
@@ -26,6 +27,7 @@
             ["wrapper/stdio.h", "stdio.h"],
             ["wrapper/unistd.h", "unistd.h"],
             ["wrapper/stdlib.h", "stdlib.h"],
+            ["wrapper/fnmatch.h", "fnmatch.h"],
             "err.h"
         ]
     }

--- a/util/fnmatch.c
+++ b/util/fnmatch.c
@@ -3,8 +3,7 @@
 #include <ctype.h>
 #include <fnmatch.h>
 
-#define FNM_FILE_NAME FNM_PATHNAME // Preferred GNU name
-#define FNM_CASEFOLD  0x4000000    // Some large power of 2 to avoid collisions
+#define FNM_CASEFOLD  0x4000000 // Some large power of 2 to avoid collisions
 
 void str_to_lower(char *str) {
   while (*str) {
@@ -34,7 +33,7 @@ int libutil_fnmatch(const char *pattern, const char *string, int flags)
 
 
     // Use fnmatch to compare the lowercase strings
-    result = fnmatch(lower_pattern, lower_string, flags);
+    result = fnmatch(lower_pattern, lower_string, flags ^ FNM_CASEFOLD);
 
     // Clean up
     free(lower_pattern);

--- a/util/fnmatch.c
+++ b/util/fnmatch.c
@@ -1,0 +1,47 @@
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <fnmatch.h>
+
+#define FNM_FILE_NAME FNM_PATHNAME // Preferred GNU name
+#define FNM_CASEFOLD  0x4000000    // Some large power of 2 to avoid collisions
+
+void str_to_lower(char *str) {
+  while (*str) {
+    *str = tolower((unsigned char) *str);
+    str++;
+  }
+}
+
+int libutil_fnmatch(const char *pattern, const char *string, int flags)
+{
+  int result;
+
+  if (flags & FNM_CASEFOLD)
+  {
+    // Create copies of the pattern and the string
+    char *lower_pattern = strdup(pattern);
+    char *lower_string = strdup(string);
+    if (!lower_pattern || !lower_string) {
+        free(lower_pattern);
+        free(lower_string);
+        return FNM_NOMATCH;
+    }
+
+    // Convert copies to lowercase
+    str_to_lower(lower_pattern);
+    str_to_lower(lower_string);
+
+
+    // Use fnmatch to compare the lowercase strings
+    result = fnmatch(lower_pattern, lower_string, flags);
+
+    // Clean up
+    free(lower_pattern);
+    free(lower_string);
+  } else {
+    result = fnmatch(pattern, string, flags);
+  }
+
+  return result;
+}

--- a/util/libutil.exp
+++ b/util/libutil.exp
@@ -22,3 +22,4 @@ libutil_vwarnx
 libutil_isatty
 libutil_getprogname
 libutil_setprogname
+libutil_fnmatch

--- a/util/wrapper/fnmatch.h
+++ b/util/wrapper/fnmatch.h
@@ -1,0 +1,23 @@
+#ifndef LIBUTIL_FNMATCH_H
+#define LIBUTIL_FNMATCH_H
+
+/* Include the real fnmatch.h. We don't want to recreate all the stuff */
+/* it contains - just overwrite the fnmatch function declaration in it */
+#include_next <fnmatch.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _GNU_SOURCE
+#define FNM_FILE_NAME FNM_PATHNAME // Preferred GNU name
+#define FNM_CASEFOLD  0x4000000    // Some large power of 2 to avoid collisions
+#endif
+
+int fnmatch(const char *, const char*, int) __asm__ ("libutil_fnmatch");
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
* Implement FNM_CASEFOLD to allow for case-insensitive matching with fnmatch
* Create a FNM_PATHNAME alias of FNM_FILE_NAME for GNU compatibility
