### PR TITLE
Force creation of symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ perfstat/libiperf.so.1: perfstat/libiperf.o perfstat/libiperf.imp
 	rm -r perfstat/libiperf.tmp
 
 perfstat/libiperf.so: perfstat/libiperf.so.1
-	ln -s libiperf.so.1 perfstat/libiperf.so
+	ln -sf libiperf.so.1 perfstat/libiperf.so
 
 perfstat/libiperf.target: perfstat/libiperf.so
 
@@ -67,7 +67,7 @@ util/libutil.so.2: util/libutil.o util/libutil.imp
 	rm -r util/libutil.tmp
 
 util/libutil.so: util/libutil.so.2
-	ln -s libutil.so.2 util/libutil.so
+	ln -sf libutil.so.2 util/libutil.so
 
 util/libutil.target: util/libutil.so
 

--- a/generate.py
+++ b/generate.py
@@ -74,7 +74,7 @@ for cfg in sorted(glob('*/build.json')):
 	rm -r {cfg_dir}/{name}.tmp
 
 {cfg_dir}/{name}.so: {cfg_dir}/{soname}
-	ln -s {soname} {cfg_dir}/{name}.so
+	ln -sf {soname} {cfg_dir}/{name}.so
 
 {cfg_dir}/{name}.target: {cfg_dir}/{name}.so
 """


### PR DESCRIPTION
When running make after the .so has already been symlinked, force the symlink to be recreated so that it doesn't error and force user to run make clean.

Ran into this issue while working on #32, kept having to run `make clean`. Now it should work to just run `make` every time a change is made, without having to delete the `.so`. Tested and working.

Fixes #24 